### PR TITLE
Housekeeping: install script hardening and quality improvements.

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 #
-# Copyright(C) 2019-2025, The Homebridge Team. All rights reserved.
+# Copyright(C) 2019-2026, The Homebridge Team. All rights reserved.
 #
 # Dockerfile.linux: create a cross-compilation environment to build FFmpeg statically for multiple CPU architectures, using QEMU emulation only when needed.
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 #
-# Copyright(C) 2019-2025, The Homebridge Team. All rights reserved.
+# Copyright(C) 2019-2026, The Homebridge Team. All rights reserved.
 #
 # Dockerfile.windows: create a cross-compilation environment to build FFmpeg statically for Windows using a Linux host system.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,11 @@
+/* Copyright(C) 2019-2026, The Homebridge Team. All rights reserved.
+ *
+ * index.d.ts: TypeScript type definitions for the FFmpeg binary path export.
+ */
+
+/**
+ * Absolute path to the FFmpeg binary bundled with this package, or `undefined` if the binary is not available. Consumers should fall back to a system-installed FFmpeg
+ * when this value is `undefined`.
+ */
 declare const ffmpegPath: string | undefined;
-export default ffmpegPath;
+export = ffmpegPath;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/* Copyright(C) 2019-2026, The Homebridge Team. All rights reserved.
+ *
+ * index.js: Main entry point. Exports the path to the FFmpeg binary, or undefined if unavailable.
+ */
 const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs");

--- a/install.js
+++ b/install.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/* Copyright(C) 2019-2025, The Homebridge Team. All rights reserved.
+/* Copyright(C) 2019-2026, The Homebridge Team. All rights reserved.
  *
  * install.js: Install platform-specific versions of FFmpeg that has been statically built.
  */
@@ -13,45 +13,36 @@ const child_process = require("node:child_process");
 
 const tar = require("tar");
 
-// Define the number of times we'll retry a failed download before giving up entirely.
+// Retry a failed download up to this many times before giving up (3 total attempts: initial + 2 retries).
 const DOWNLOAD_RETRY_ATTEMPTS = 2;
 
-// Define the maximum number of HTTP redirects we'll follow before considering it an error. This prevents infinite redirect loops while still allowing for CDN redirects.
+// Maximum HTTP redirects to follow before treating it as an error. Prevents infinite redirect loops while allowing CDN redirects.
 const MAX_REDIRECTS = 5;
 
-// Define the network timeout in milliseconds. Connections that don't respond within this time will be aborted.
+// Network timeout in milliseconds. Connections that don't respond within this time will be aborted.
 const REQUEST_TIMEOUT_MS = 30000;
 
-// Define the minimum macOS version we support. Versions older than Sequoia (macOS 15) are not compatible with our precompiled FFmpeg binaries.
+// Minimum macOS version we support. The value is a Darwin kernel version, not the user-visible macOS number...kernel 24 corresponds to macOS 15 (Sequoia).
 const MACOS_MINIMUM_SUPPORTED_VERSION = 24;
 const MACOS_MINIMUM_SUPPORTED_RELEASE = "Sequoia";
 
-// Define file system constants for better maintainability.
+// File system constants.
 const CACHE_DIR_NAME = ".build";
 const TEMP_DOWNLOAD_FILENAME = ".download";
 const FFMPEG_BINARY_NAME_UNIX = "ffmpeg";
 const FFMPEG_BINARY_NAME_WINDOWS = "ffmpeg.exe";
 
-// Define tar extraction constants. The tar.gz packages have FFmpeg nested four directories deep at /usr/local/bin/, so we need to strip these path components during
-// extraction.
+// The tar.gz archives nest FFmpeg four directories deep at usr/local/bin/ffmpeg, so we strip these path components during extraction.
 const TAR_STRIP_COMPONENTS = 4;
 
-// Define file permission constants for Unix-like systems.
 const EXECUTABLE_PERMISSIONS = 0o755;
-
-// Define HTTP status codes for better readability.
 const HTTP_STATUS_OK = 200;
-
-// Define GitHub release URL components.
 const GITHUB_RELEASE_BASE_URL = "https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/";
-
-// Define console output colors for better user feedback.
 const CONSOLE_COLOR_CYAN = "\x1b[36m";
 const CONSOLE_COLOR_RESET = "\x1b[0m";
 
 /**
- * Retrieves the target FFmpeg release version from the npm package version. This ensures that we download the correct FFmpeg binary version that matches the version of
- * this npm package being installed.
+ * Retrieves the target FFmpeg release version from the npm package version. This ensures we download the binary that matches the npm package being installed.
  *
  * @returns {string} The release version string prefixed with 'v'.
  */
@@ -61,8 +52,7 @@ function targetFfmpegRelease() {
 }
 
 /**
- * Determines the cache directory path where downloaded FFmpeg binaries will be stored. This provides a consistent location for caching downloads across multiple
- * installation attempts, preventing unnecessary re-downloads.
+ * Returns the absolute path to the cache directory where downloaded FFmpeg binaries are stored.
  *
  * @returns {string} The absolute path to the cache directory.
  */
@@ -72,43 +62,16 @@ function ffmpegCache() {
 }
 
 /**
- * Creates the FFmpeg cache directory with all necessary parent directories. This ensures we have a place to store our downloaded binaries before extraction.
+ * Determines the appropriate FFmpeg binary filename to download based on the current operating system and CPU architecture.
  *
- * @returns {void}
+ * @returns {string|null} The filename to download, or null if the platform is not supported.
  */
-function makeFfmpegCacheDir() {
+function getDownloadFileName() {
 
-  fs.mkdirSync(ffmpegCache(), { recursive: true });
-}
-
-/**
- * Ensures the FFmpeg cache directory exists, creating it if necessary. This is a safety check that prevents file system errors when attempting to write downloaded files.
- *
- * @returns {void}
- */
-function ensureFfmpegCacheDir() {
-
-  // Check if the cache directory already exists. If it doesn't, we need to create it before proceeding with any download operations.
-  if(!fs.existsSync(ffmpegCache())) {
-
-    return makeFfmpegCacheDir();
-  }
-}
-
-/**
- * Determines the appropriate FFmpeg binary filename to download based on the current operating system and CPU architecture. This ensures we download a binary that will
- * actually run on the user's system.
- *
- * @returns {Promise<string|null>} The filename to download, or null if the platform is not supported.
- */
-async function getDownloadFileName() {
-
-  // The list of operating systems we support.
   switch(os.platform()) {
 
     case "darwin":
 
-      // macOS systems need different binaries for Apple Silicon and Intel processors.
       switch(process.arch) {
 
         case "x64":
@@ -126,7 +89,7 @@ async function getDownloadFileName() {
 
     case "linux":
 
-      // Linux systems have multiple architectures we need to support. We use Alpine Linux builds for their strong static-build compatibility.
+      // We use Alpine Linux builds for their strong static-build compatibility.
       switch(process.arch) {
 
         case "x64":
@@ -148,7 +111,6 @@ async function getDownloadFileName() {
 
     case "freebsd":
 
-      // FreeBSD support is x64-only.
       switch(process.arch) {
 
         case "x64":
@@ -162,7 +124,7 @@ async function getDownloadFileName() {
 
     case "win32":
 
-      // Windows only supports x64 architectures. The platform name "win32" is used for all Windows systems regardless of architecture...a historical anachronism.
+      // The platform name "win32" is used for all Windows systems regardless of architecture...a historical anachronism.
       if(process.arch === "x64") {
 
         return FFMPEG_BINARY_NAME_WINDOWS;
@@ -172,31 +134,26 @@ async function getDownloadFileName() {
 
     default:
 
-      // Any other operating system is not supported by our precompiled binaries.
       return null;
   }
 }
 
 /**
- * Performs a single download attempt for the FFmpeg binary using native Node.js HTTPS module. This function handles the HTTP request, follows redirects, and manages the
- * file writing process.
+ * Performs a single download attempt for the FFmpeg binary. Handles the HTTP request, follows redirects, streams to disk, and provides progress feedback.
  *
  * @param {string} downloadUrl - The complete URL to download the FFmpeg binary from.
  * @param {string} tempFile - The temporary file path to write the download to.
  * @param {string} ffmpegDownloadPath - The final destination path for the downloaded file.
- * @param {number} redirectCount - The number of redirects we've followed (to prevent infinite redirect loops).
+ * @param {number} redirectCount - The number of redirects followed so far.
  * @returns {Promise<void>} Resolves when the download completes successfully, rejects on error.
  */
 function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCount = 0) {
 
-  // We use a promise here so we can tailor the retrieval to our needs and provide progress tracking, efficient streaming of our download to disk, custom error, redirect
-  // and timeout handling.
+  // We use a manual promise so we can provide progress tracking, efficient streaming to disk, and custom redirect/timeout handling.
   return new Promise((resolve, reject) => {
 
-    // Parse the URL to extract the components needed for the HTTPS request. This gives us the hostname, path, and other URL components in a structured format.
     const urlParts = new URL(downloadUrl);
 
-    // Configure the HTTPS request options. We include a user agent to identify our script and set a reasonable timeout to prevent hanging on slow connections.
     const options = {
 
       headers: { "User-Agent": "ffmpeg-for-homebridge-installer" },
@@ -206,13 +163,11 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
       timeout: REQUEST_TIMEOUT_MS
     };
 
-    // Create a write stream for saving the downloaded file to disk. We'll pipe the response data directly to this stream for memory efficiency.
     const file = fs.createWriteStream(tempFile);
 
-    // Keep track of whether we've already cleaned up resources. This prevents double-cleanup in error scenarios where multiple error events might fire.
+    // Prevents double-cleanup when multiple error events fire for the same failure.
     let cleaned = false;
 
-    // Helper function to clean up resources when an error occurs. This ensures we don't leave file handles open or partial files on disk.
     const cleanup = () => {
 
       if(!cleaned) {
@@ -227,13 +182,11 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
       }
     };
 
-    // Initiate the request to download the FFmpeg binary from GitHub releases.
     const request = https.get(options, (response) => {
 
-      // Handle redirect responses (3xx status codes). GitHub often redirects to CDN servers, so we need to follow these redirects to get to the actual file.
+      // GitHub redirects to CDN servers, so we follow 3xx responses to the actual download location.
       if((response.statusCode >= 300) && (response.statusCode < 400) && response.headers.location) {
 
-        // Check if we've exceeded the maximum number of redirects. This prevents infinite redirect loops that could occur with misconfigured servers.
         if(redirectCount >= MAX_REDIRECTS) {
 
           cleanup();
@@ -242,21 +195,18 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
           return;
         }
 
-        // Close the current file stream and follow the redirect to the new location.
-        file.close();
-        fs.unlinkSync(tempFile);
+        // Using cleanup() rather than manual close/unlink ensures the cleaned flag is set, preventing late error events on the abandoned request from attempting a
+        // second cleanup.
+        cleanup();
 
-        // Handle both relative and absolute redirect URLs. Relative URLs need to be resolved against the current URL to get the complete path.
+        // Resolve both absolute and relative redirect URLs.
         const redirectUrl = response.headers.location.startsWith("http") ? response.headers.location : new URL(response.headers.location, downloadUrl).toString();
 
-        // Recursively call performDownload with the new URL and increment the redirect counter.
         performDownload(redirectUrl, tempFile, ffmpegDownloadPath, redirectCount + 1).then(resolve).catch(reject);
 
         return;
       }
 
-      // Check if we received a successful response. Anything other than 200 OK is considered an error for our
-      // purposes since we're expecting a direct file download.
       if(response.statusCode !== HTTP_STATUS_OK) {
 
         cleanup();
@@ -265,21 +215,16 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
         return;
       }
 
-      // Calculate the total size of the file being downloaded. We default to 1 to avoid divide-by-zero errors if the content-length header is missing.
+      // Default to 1 to avoid divide-by-zero when the content-length header is missing.
       const totalBytes = parseInt(response.headers["content-length"], 10) || 1;
       let downloadedBytes = 0;
 
-      // Track download progress and update the console with the current percentage. This gives users feedback that the download is progressing.
       response.on("data", (chunk) => {
 
         downloadedBytes += chunk.length;
         process.stdout.write("\r" + Math.round((downloadedBytes / totalBytes) * 100).toString() + "%.");
       });
 
-      // Handle the end of the response stream. At this point, all data has been received from the server.
-      response.on("end", () => file.end());
-
-      // Handle any errors that occur during the response stream. These could be network errors or timeouts.
       response.on("error", (error) => {
 
         console.log("Response stream error: ", error);
@@ -287,7 +232,6 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
         reject(error);
       });
 
-      // Handle any file system errors that occur during the write process. These could be disk full errors or permission issues.
       file.on("error", (error) => {
 
         console.log("File system error: ", error);
@@ -295,12 +239,11 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
         reject(error);
       });
 
-      // Handle the finish event, which fires when all data has been written to the file successfully.
+      // The finish event fires after all piped data has been flushed to disk.
       file.on("finish", () => {
 
         console.log(" - Download complete.");
 
-        // Only rename if the file exists and the download completed successfully. This prevents errors if something went wrong during the download process.
         if(fs.existsSync(tempFile)) {
 
           fs.renameSync(tempFile, ffmpegDownloadPath);
@@ -311,13 +254,10 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
         }
       });
 
-      // Pipe the response data directly to the file. This is more memory-efficient than buffering the entire file in memory, especially important for large binary files
-      // like FFmpeg.
+      // Pipe directly to the file stream to avoid buffering the entire binary in memory.
       response.pipe(file);
     });
 
-    // Handle request-level errors such as DNS failures, connection timeouts, or other network issues. These are different from HTTP errors and indicate problems
-    // establishing the connection.
     request.on("error", (error) => {
 
       console.log("Network error: ", error);
@@ -325,7 +265,7 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
       reject(error);
     });
 
-    // Handle timeout events. If the server doesn't respond within our timeout period, we abort the request to avoid hanging indefinitely.
+    // Abort if the server doesn't respond within our timeout period to avoid hanging indefinitely.
     request.on("timeout", () => {
 
       console.log("Request timed out.");
@@ -337,8 +277,7 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
 }
 
 /**
- * Downloads the FFmpeg binary from GitHub releases with automatic retry logic. This function handles network errors gracefully and provides progress feedback to the
- * user during the download process.
+ * Downloads the FFmpeg binary from GitHub releases with automatic retry logic.
  *
  * @param {string} downloadUrl - The complete URL to download the FFmpeg binary from.
  * @param {string} ffmpegDownloadPath - The local file path where the downloaded file should be saved.
@@ -347,20 +286,17 @@ function performDownload(downloadUrl, tempFile, ffmpegDownloadPath, redirectCoun
  */
 async function downloadFfmpeg(downloadUrl, ffmpegDownloadPath, retries = DOWNLOAD_RETRY_ATTEMPTS) {
 
-  // Create a temporary file path for the download. We download to a temp file first to avoid leaving partial files if the download is interrupted.
+  // Download to a temp file first to avoid leaving partial files if the download is interrupted.
   const tempFile = path.resolve(ffmpegCache(), TEMP_DOWNLOAD_FILENAME);
 
   console.log("Downloading FFmpeg from: " + downloadUrl);
 
-  // Keep track of the current attempt number for error reporting. This helps users understand how many attempts have been made.
   let attemptNumber = 0;
 
-  // Continue trying to download until we succeed or exhaust all retry attempts.
   while(attemptNumber <= retries) {
 
     try {
 
-      // Attempt to perform the download. If this succeeds, we'll return immediately. If it fails, we'll catch the error and potentially retry.
       await performDownload(downloadUrl, tempFile, ffmpegDownloadPath);
 
       return;
@@ -368,13 +304,11 @@ async function downloadFfmpeg(downloadUrl, ffmpegDownloadPath, retries = DOWNLOA
 
       attemptNumber++;
 
-      // Check if we have more retry attempts available. If we do, inform the user and try again. If not, throw the error to fail the entire operation.
       if(attemptNumber <= retries) {
 
         console.log("Download failed on attempt " + attemptNumber + ". Retrying...");
       } else {
 
-        // We've exhausted all retry attempts, so we need to fail with an appropriate error message that includes the original error for debugging purposes.
         throw new Error("Failed to download after " + (retries + 1) + " attempts. Last error: " + error.message);
       }
     }
@@ -382,8 +316,7 @@ async function downloadFfmpeg(downloadUrl, ffmpegDownloadPath, retries = DOWNLOA
 }
 
 /**
- * Verifies that the downloaded FFmpeg binary is functional by attempting to execute it with a simple command. This prevents us from installing a corrupted or
- * incompatible binary.
+ * Verifies that the downloaded FFmpeg binary is functional by running a lightweight command. Prevents installing a corrupted or incompatible binary.
  *
  * @param {string} ffmpegTempPath - The path to the FFmpeg binary to test.
  * @returns {boolean} True if the binary executes successfully, false otherwise.
@@ -392,20 +325,19 @@ function binaryOk(ffmpegTempPath) {
 
   try {
 
-    // Attempt to run FFmpeg with the -buildconf flag, which simply outputs build configuration without processing any media files. This is a quick way to verify the binary works.
-    child_process.execSync(ffmpegTempPath + " -buildconf");
+    // The -buildconf flag outputs build configuration without processing media...a quick, side-effect-free validation. We use execFileSync so the binary path is
+    // passed directly to the OS without shell interpretation.
+    child_process.execFileSync(ffmpegTempPath, ["-buildconf"]);
 
     return true;
   } catch(e) {
 
-    // If the execution fails for any reason, the binary is not usable on this system.
     return false;
   }
 }
 
 /**
- * Displays a helpful error message to the user when FFmpeg installation fails. This ensures users understand that while the plugin installed successfully, they may need
- * to manually install FFmpeg.
+ * Displays a fallback message when FFmpeg installation fails, letting users know the plugin installed but FFmpeg may need manual setup.
  *
  * @returns {void}
  */
@@ -415,57 +347,71 @@ function displayErrorMessage() {
 }
 
 /**
- * Main installation function that orchestrates the entire FFmpeg download and setup process. This function handles platform detection, downloading, extraction, and
- * verification of the FFmpeg binary.
+ * Handles a graceful installation failure. Logs the reason, displays the fallback message, optionally cleans up a file, and exits with code 0 so the Homebridge
+ * installation can continue without FFmpeg.
+ *
+ * @param {string} message - The error message explaining what went wrong.
+ * @param {string} [cleanupPath] - Optional file path to delete before exiting.
+ * @returns {never}
+ */
+function failGracefully(message, cleanupPath) {
+
+  console.error(message);
+  displayErrorMessage();
+
+  if(cleanupPath && fs.existsSync(cleanupPath)) {
+
+    fs.unlinkSync(cleanupPath);
+  }
+
+  process.exit(0);
+}
+
+/**
+ * Main installation function that orchestrates the FFmpeg download and setup process: platform detection, downloading, extraction, validation, and final placement.
  *
  * @returns {Promise<void>} Resolves when installation completes successfully.
  */
 async function install() {
 
-  // Ensure the FFmpeg cache directory exists before we attempt any file operations. This prevents errors when trying to save downloaded files.
-  ensureFfmpegCacheDir();
+  // The recursive option makes mkdirSync idempotent...it's a no-op when the directory already exists.
+  fs.mkdirSync(ffmpegCache(), { recursive: true });
 
-  // Check if we're running on a supported version of macOS. Older versions of macOS don't have the required libraries for our precompiled FFmpeg binaries.
-  if((os.platform().toString() === "darwin") && (parseInt(os.release().split(".")[0]) < MACOS_MINIMUM_SUPPORTED_VERSION)) {
+  const platform = os.platform();
+  const isWindows = platform === "win32";
+  const binaryName = isWindows ? FFMPEG_BINARY_NAME_WINDOWS : FFMPEG_BINARY_NAME_UNIX;
 
-    console.error("ffmpeg-for-homebridge: macOS versions older than " + MACOS_MINIMUM_SUPPORTED_RELEASE +
+  // Older macOS versions lack the system libraries our precompiled binaries are linked against.
+  if((platform === "darwin") && (parseInt(os.release().split(".")[0]) < MACOS_MINIMUM_SUPPORTED_VERSION)) {
+
+    failGracefully("ffmpeg-for-homebridge: macOS versions older than " + MACOS_MINIMUM_SUPPORTED_RELEASE +
       " are not supported, you will need to install a working version of FFmpeg manually.");
-
-    process.exit(0);
   }
 
-  // Determine which FFmpeg binary we need to download for the current platform and architecture.
-  const ffmpegDownloadFileName = await getDownloadFileName();
+  const ffmpegDownloadFileName = getDownloadFileName();
 
   if(!ffmpegDownloadFileName) {
 
-    console.error("ffmpeg-for-homebridge: " + os.platform() + " " + process.arch + " is not supported, you will need to install a working version of FFmpeg manually.");
-
-    process.exit(0);
+    failGracefully("ffmpeg-for-homebridge: " + platform + " " + process.arch + " is not supported, you will need to install a working version of FFmpeg manually.");
   }
 
-  // Construct the full path where the downloaded file will be cached. We include the version in the filename to support multiple versions being cached.
+  // The version is included in the cache filename to support multiple versions being cached simultaneously.
   const ffmpegDownloadPath = path.resolve(ffmpegCache(), targetFfmpegRelease() + "-" + ffmpegDownloadFileName);
-
-  // Build the complete URL for downloading the FFmpeg binary from GitHub releases.
   const downloadUrl = GITHUB_RELEASE_BASE_URL + targetFfmpegRelease() + "/" + ffmpegDownloadFileName;
 
-  // Check if we've already downloaded this version. If not, download it now. This caching prevents unnecessary downloads when reinstalling the package.
   if(!fs.existsSync(ffmpegDownloadPath)) {
 
     await downloadFfmpeg(downloadUrl, ffmpegDownloadPath);
   }
 
-  // Determine the paths for the temporary and final locations of the FFmpeg binary. Windows uses a different filename than Unix-like systems.
-  const ffmpegTempPath = path.resolve(ffmpegCache(), (os.platform() === "win32") ? FFMPEG_BINARY_NAME_WINDOWS : FFMPEG_BINARY_NAME_UNIX);
-  const ffmpegTargetPath = path.resolve(__dirname, (os.platform() === "win32") ? FFMPEG_BINARY_NAME_WINDOWS : FFMPEG_BINARY_NAME_UNIX);
+  const ffmpegTempPath = path.resolve(ffmpegCache(), binaryName);
+  const ffmpegTargetPath = path.resolve(__dirname, binaryName);
 
-  // Extract the FFmpeg binary from the tar.gz archive on Unix-like systems. Windows downloads are already executable files that don't need extraction.
-  if(os.platform() !== "win32") {
+  // Windows downloads are standalone executables...no extraction needed. Unix downloads are tar.gz archives with the binary nested at usr/local/bin/ffmpeg.
+  if(!isWindows) {
 
     try {
 
-      // Extract the FFmpeg binary from the tar.gz archive. The binary is nested several directories deep, so we strip those path components during extraction.
       await tar.x({
 
         C: ffmpegCache(),
@@ -475,50 +421,39 @@ async function install() {
     } catch(e) {
 
       console.error(e);
-      console.error("An error occurred while extracting the downloaded FFmpeg binary.");
-      displayErrorMessage();
 
-      // Delete the cached download since it appears to be corrupted or invalid. This allows a fresh download on the next installation attempt.
-      fs.unlinkSync(ffmpegDownloadPath);
-
-      process.exit(0);
+      // Delete the cached archive since it's likely corrupted, forcing a fresh download on the next attempt.
+      failGracefully("An error occurred while extracting the downloaded FFmpeg binary.", ffmpegDownloadPath);
     }
 
-    // Set the execute permission on the extracted binary. Unix-like systems require this permission for the binary to be runnable.
     if(fs.existsSync(ffmpegTempPath)) {
 
       fs.chmodSync(ffmpegTempPath, EXECUTABLE_PERMISSIONS);
     }
   } else {
 
-    // For Windows, the downloaded file is already an executable, so we just need to move it to the temp location.
-    fs.renameSync(ffmpegDownloadPath, ffmpegTempPath);
+    // Copy rather than move so the cached download survives validation failure, matching Unix behavior where tar.x() reads from the archive without removing it.
+    fs.copyFileSync(ffmpegDownloadPath, ffmpegTempPath);
   }
 
-  // Verify that the downloaded binary actually works on this system. This catches issues with incompatible architectures or missing system libraries.
   if(!binaryOk(ffmpegTempPath)) {
 
-    displayErrorMessage();
+    // Delete the cached archive to force a fresh download on the next attempt.
+    fs.unlinkSync(ffmpegDownloadPath);
 
-    // Clean up the failed binary. On Windows, the download was moved (not copied) to ffmpegTempPath, so we delete that. On Unix, we delete the cached archive to allow a
-    // fresh download on the next attempt.
-    fs.unlinkSync((os.platform() === "win32") ? ffmpegTempPath : ffmpegDownloadPath);
-
-    process.exit(0);
+    failGracefully("The downloaded FFmpeg binary failed validation.", ffmpegTempPath);
   }
 
-  // Move the verified binary to its final location in the npm package directory. This is where the main package code will look for it.
   fs.renameSync(ffmpegTempPath, ffmpegTargetPath);
 
   console.log(CONSOLE_COLOR_CYAN + "\nFFmpeg has been downloaded to " + ffmpegTargetPath + "." + CONSOLE_COLOR_RESET);
 
-  // Explicitly exit to ensure the process terminates promptly. Without this, lingering handles from HTTPS requests or tar extraction can keep the event loop alive.
+  // Explicitly exit to prevent lingering HTTPS or tar handles from keeping the event loop alive.
   process.exit(0);
 }
 
 /**
- * Bootstrap function that initiates the installation process and handles top-level errors. This provides a clean entry point for the script and ensures proper error
- * handling.
+ * Entry point that initiates installation and handles top-level errors.
  *
  * @returns {Promise<void>} Resolves when the bootstrap process completes.
  */
@@ -531,7 +466,7 @@ async function bootstrap() {
     await install();
   } catch(e) {
 
-    // Check if the error is due to permission issues. This commonly happens when installing global npm packages without proper permissions.
+    // Permission issues commonly happen when installing global npm packages without --unsafe-perm.
     if(e && e.code && (e.code === "EACCES")) {
 
       console.log("Unable to download FFmpeg.");
@@ -540,10 +475,9 @@ async function bootstrap() {
 
     displayErrorMessage();
 
-    // Use setTimeout to ensure all console output is flushed before the process exits.
+    // setTimeout ensures all console output is flushed before the process exits.
     setTimeout(() => process.exit(0));
   }
 }
 
-// Start the installation process when this script is executed.
 bootstrap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "ffmpeg-for-homebridge",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffmpeg-for-homebridge",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "dependencies": {
-        "tar": "^7.5.6"
+        "tar": "^7.5.12"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -58,9 +58,10 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
+      "integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -110,9 +111,9 @@
       }
     },
     "tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.12",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.12.tgz",
+      "integrity": "sha512-9TsuLcdhOn4XztcQqhNyq1KOwOOED/3k58JAvtULiYqbO8B/0IBAAIE1hj0Svmm58k27TmcigyDI0deMlgG3uw==",
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffmpeg-for-homebridge",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Static FFmpeg binaries for Homebridge camera plugins to support HomeKit video streaming (AAC-ELD and H.264) and hardware-accelerated transcoding (QSV, V4L2M2M, VideoToolbox).",
   "author": {
     "name": "The Homebridge Team",
@@ -15,7 +15,7 @@
     "url": "https://github.com/homebridge/ffmpeg-for-homebridge/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "main": "index.js",
   "typings": "index.d.ts",
@@ -39,6 +39,6 @@
     "videotoolbox"
   ],
   "dependencies": {
-    "tar": "^7.5.6"
+    "tar": "^7.5.12"
   }
 }


### PR DESCRIPTION
  Title:                                                                                                                                                                                                                                                
  Housekeeping: install script hardening and quality improvements.
                                                                                                                                                                                                                                                        
  Body:                                                                                                                                                                                                                                               
  ## Summary                                                                                                                                                                                                                                            
            
  - **install.js security:** replaced `execSync` with `execFileSync` for binary validation, eliminating shell interpretation of the file path.                                                                                                          
  - **install.js correctness:** Windows now uses `copyFileSync` instead of `renameSync` to preserve the download cache across validation failures, matching Unix behavior. Redirect cleanup now uses the `cleanup()` helper to properly set the guard   
  flag against double-cleanup. Removed redundant `response.on("end")` call that `pipe()` already handles.                                                                                                                                               
  - **install.js structure:** collapsed the three-function `ensureFfmpegCacheDir`/`makeFfmpegCacheDir` chain into a single idempotent `mkdirSync({ recursive: true })` call. Introduced `failGracefully()` helper to consolidate four repeated          
  error-exit patterns. Captured `platform`/`isWindows`/`binaryName` once instead of calling `os.platform()` 6+ times. Removed spurious `async` from `getDownloadFileName()`. Trimmed comments that restated the code while preserving all rationale     
  comments.                                                                                                                                                                                                                                             
  - **index.d.ts:** fixed CJS/ESM mismatch (`export default` → `export =`), added copyright header and JSDoc documenting the export contract.                                                                                                           
  - **index.js:** added copyright header.                                                                                                                                                                                                               
  - **Dockerfiles:** updated copyright years to 2026.                                                                                                                                                                                                   
  - **Dependencies:** bumped `tar` to ^7.5.12, Node engine to >=22 since Node 20 is EOL shortly.
                                                                                   
  ## Test plan                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                        
  - [X] Verify `npm ci && npm install` completes successfully on a supported platform (downloads and validates the FFmpeg binary).                                                                                                                      
  - [X] Verify on an unsupported platform or old macOS that the install exits gracefully with a helpful message.                                                                                                                                        
  - [X] Verify TypeScript consumers can import the package without `esModuleInterop`.                                                                                                                                                                   